### PR TITLE
feat(journey): implement collection promotion to journey feature

### DIFF
--- a/src/app/actions/journey.ts
+++ b/src/app/actions/journey.ts
@@ -17,9 +17,20 @@ export async function saveJourney(
   return { error: "Use saveJourneyData instead" };
 }
 
-import { JourneyResponse, RefineAnswer } from "@/lib/types";
-import type { JourneyItem } from "@/lib/types";
+import {
+  EnrichedRecommendation,
+  JourneyResponse,
+  RefineAnswer,
+} from "@/lib/types";
+import type { JourneyItem, JourneyItemRaw, PromoteItem } from "@/lib/types";
 import { parseRuntimeMinutes } from "@/lib/runtime";
+import { generateJourneyFromList } from "@/lib/ai";
+import { JOURNEY_MAX_ITEMS } from "@/config/journey";
+import {
+  inferContentTypeFromPromoteItems,
+  mergePromotedJourneyItems,
+} from "@/lib/promote-journey";
+import type { CollectionItem } from "@/lib/supabase/types";
 
 // ...
 
@@ -32,6 +43,8 @@ export async function saveJourneyData(data: {
   refinement_steps?: RefineAnswer[];
   is_public?: boolean;
   is_explicitly_saved?: boolean;
+  /** When set, links this journey to the collection it was promoted from */
+  source_collection_id?: string | null;
 }) {
   const supabase = await createClient();
 
@@ -63,6 +76,7 @@ export async function saveJourneyData(data: {
       status: "wishlist",
       is_public: data.is_public ?? false,
       is_explicitly_saved: data.is_explicitly_saved ?? true,
+      source_collection_id: data.source_collection_id ?? null,
     })
     .select("id")
     .single();
@@ -99,7 +113,163 @@ export async function saveJourneyData(data: {
   }
 
   revalidatePath("/profile");
+  if (data.source_collection_id) {
+    revalidatePath(`/collections/${data.source_collection_id}`);
+  }
   return { success: true, journeyId: newJourney.id };
+}
+
+function collectionRowToPromoteItem(row: CollectionItem): PromoteItem | null {
+  const meta = row.metadata as Partial<EnrichedRecommendation> | null;
+  const title = (row.title || meta?.title || "").trim();
+  if (!title) return null;
+
+  const typeRaw = (row.media_type || meta?.type || "movie").toLowerCase();
+  const type = (
+    ["movie", "tv", "book", "anime"].includes(typeRaw) ? typeRaw : "movie"
+  ) as PromoteItem["type"];
+
+  const year =
+    typeof meta?.year === "number" && !Number.isNaN(meta.year)
+      ? meta.year
+      : 0;
+
+  const genres = Array.isArray(meta?.genres) ? meta.genres : [];
+
+  return {
+    title,
+    year,
+    type,
+    genres,
+    description: meta?.description,
+    creator: meta?.creator,
+    posterUrl: row.image_url ?? meta?.posterUrl ?? null,
+    externalId: meta?.externalId ?? null,
+    runtime: meta?.runtime ?? null,
+    rating: meta?.rating ?? null,
+    ratingSource: meta?.ratingSource ?? null,
+  };
+}
+
+export async function promoteCollectionToJourney(collectionId: string): Promise<{
+  journeyId?: string;
+  error?: string;
+}> {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return { error: "You must be logged in to create a journey." };
+  }
+
+  const { data: collection, error: colError } = await supabase
+    .from("collections")
+    .select("id, user_id, name, description")
+    .eq("id", collectionId)
+    .single();
+
+  if (colError || !collection) {
+    return { error: "Collection not found." };
+  }
+
+  if (collection.user_id !== user.id) {
+    return { error: "You can only promote your own lists." };
+  }
+
+  const { data: existingJourney } = await supabase
+    .from("journeys")
+    .select("id")
+    .eq("source_collection_id", collectionId)
+    .maybeSingle();
+
+  if (existingJourney?.id) {
+    return { error: "This list has already been turned into a journey." };
+  }
+
+  const { data: rows, error: itemsError } = await supabase
+    .from("collection_items")
+    .select("*")
+    .eq("collection_id", collectionId)
+    .order("position", { ascending: true });
+
+  if (itemsError) {
+    return { error: itemsError.message };
+  }
+
+  const promoteItems = (rows || [])
+    .map(collectionRowToPromoteItem)
+    .filter((p): p is PromoteItem => p !== null);
+
+  if (promoteItems.length === 0) {
+    return { error: "Add at least one item to your list before creating a journey." };
+  }
+
+  const contentType = inferContentTypeFromPromoteItems(promoteItems);
+
+  let aiResult;
+  try {
+    aiResult = await generateJourneyFromList(promoteItems, contentType, {
+      collectionName: collection.name,
+      collectionDescription: collection.description,
+      maxItems: JOURNEY_MAX_ITEMS,
+    });
+  } catch (e) {
+    console.error("promoteCollectionToJourney AI error:", e);
+    return {
+      error:
+        e instanceof Error
+          ? e.message
+          : "Failed to generate journey from your list.",
+    };
+  }
+
+  const rawItems = (aiResult.items || []) as JourneyItemRaw[];
+  if (rawItems.length === 0) {
+    return {
+      error:
+        "Craveo couldn't assemble a valid journey from your list. Try again.",
+    };
+  }
+
+  const mergedItems = mergePromotedJourneyItems(rawItems, promoteItems);
+
+  const totalRuntimeMinutes = mergedItems.reduce((sum, item) => {
+    const m = parseRuntimeMinutes(item.runtime);
+    return sum + (m ?? 0);
+  }, 0);
+
+  const journeyTitle =
+    (aiResult.journey_title ?? "").trim() || collection.name;
+
+  const results: JourneyResponse = {
+    journeyTitle,
+    description: aiResult.description ?? "",
+    totalRuntimeMinutes:
+      totalRuntimeMinutes > 0 ? totalRuntimeMinutes : undefined,
+    difficultyProgression:
+      aiResult.difficulty_progression ?? aiResult.difficultyProgression ?? "",
+    items: mergedItems,
+    itemCount: mergedItems.length,
+  };
+
+  const save = await saveJourneyData({
+    title: journeyTitle,
+    query: `Promoted from Cravelist: ${collection.name}`,
+    results,
+    refinement_steps: [],
+    is_public: false,
+    is_explicitly_saved: true,
+    source_collection_id: collectionId,
+  });
+
+  if (save.error) {
+    return { error: save.error };
+  }
+
+  return { journeyId: save.journeyId };
 }
 
 export async function beginJourney(

--- a/src/app/api/collections/suggest-name/route.ts
+++ b/src/app/api/collections/suggest-name/route.ts
@@ -39,7 +39,7 @@ Guidelines:
 ["Weekend Binges", "Sci-Fi Masterpieces", "Tears & Tissues", "Rainy Day Reads"]`;
 
     const response = await anthropic.messages.create({
-      model: "claude-3-haiku-20240307",
+      model: process.env.CLAUDE_MODEL || "claude-sonnet-4-20250514",
       max_tokens: 150,
       messages: [{ role: "user", content: prompt }],
       temperature: 0.7,

--- a/src/app/collections/[id]/CollectionDetailClient.tsx
+++ b/src/app/collections/[id]/CollectionDetailClient.tsx
@@ -27,6 +27,7 @@ import {
   Trash2,
   Star,
   ChevronDown,
+  ListOrdered,
 } from "lucide-react";
 import Link from "next/link";
 import { useState, useEffect, useRef } from "react";
@@ -54,6 +55,10 @@ import {
 import { useLists } from "@/hooks/useLists";
 import Toast from "@/components/Toast";
 import { CRAVELIST_LABEL, CRAVELIST_LABEL_PLURAL } from "@/config/labels";
+import { JOURNEY_MAX_ITEMS } from "@/config/journey";
+import { JOURNEY_CURATING_MESSAGES } from "@/config/curating-loader-messages";
+import { useRotatingCuratingMessage } from "@/hooks/useRotatingCuratingMessage";
+import { promoteCollectionToJourney } from "@/app/actions/journey";
 import {
   DndContext,
   closestCenter,
@@ -94,6 +99,8 @@ interface CollectionDetailClientProps {
   existingCloneId?: string | null;
   contentStats?: { favorites_count: number; views_count: number };
   savesCount?: number;
+  /** Journey created from this collection via promote (one-time) */
+  linkedJourneyId?: string | null;
 }
 
 export default function CollectionDetailClient({
@@ -108,6 +115,7 @@ export default function CollectionDetailClient({
   existingCloneId = null,
   contentStats,
   savesCount = 0,
+  linkedJourneyId = null,
 }: CollectionDetailClientProps) {
   const [isPublic, setIsPublic] = useState(initialIsPublic);
   const [isShareModalOpen, setIsShareModalOpen] = useState(false);
@@ -126,6 +134,12 @@ export default function CollectionDetailClient({
     collection.description ?? "",
   );
   const [isSavingCollection, setIsSavingCollection] = useState(false);
+  const [isPromoteModalOpen, setIsPromoteModalOpen] = useState(false);
+  const [isPromotingJourney, setIsPromotingJourney] = useState(false);
+  const { message: promoteLoaderMessage, index: promoteLoaderIndex } =
+    useRotatingCuratingMessage(JOURNEY_CURATING_MESSAGES, {
+      active: isPromotingJourney,
+    });
 
   const [viewMode, setViewMode] = useState<"grid" | "list">("grid");
   const [isEditMode, setIsEditMode] = useState(false);
@@ -260,6 +274,23 @@ export default function CollectionDetailClient({
       setToastMessage(result.error);
     } else {
       router.push("/profile");
+    }
+  };
+
+  const handleConfirmPromoteJourney = async () => {
+    setIsPromoteModalOpen(false);
+    setIsPromotingJourney(true);
+    try {
+      const result = await promoteCollectionToJourney(collection.id);
+      if (result.error) {
+        setToastMessage(result.error);
+        return;
+      }
+      if (result.journeyId) {
+        router.push(`/journey/${result.journeyId}`);
+      }
+    } finally {
+      setIsPromotingJourney(false);
     }
   };
 
@@ -795,6 +826,25 @@ export default function CollectionDetailClient({
               <Plus className="w-3.5 h-3.5" />
               <span>Add Item</span>
             </button>
+            {orderedItems.length > 0 &&
+              (linkedJourneyId ? (
+                <Link
+                  href={`/journey/${linkedJourneyId}`}
+                  className="flex items-center gap-1.5 sm:gap-2 px-3 py-1.5 rounded-full text-xs font-medium transition-colors cursor-pointer border border-purple-500/50 text-purple-300 bg-purple-500/10 hover:bg-purple-500/20"
+                >
+                  <ListOrdered className="w-3.5 h-3.5" />
+                  <span>View Journey</span>
+                </Link>
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => setIsPromoteModalOpen(true)}
+                  className="flex items-center gap-1.5 sm:gap-2 px-3 py-1.5 rounded-full text-xs font-medium transition-colors cursor-pointer border border-purple-500/50 text-purple-300 bg-purple-500/10 hover:bg-purple-500/20"
+                >
+                  <ListOrdered className="w-3.5 h-3.5" />
+                  <span>Create Journey</span>
+                </button>
+              ))}
             <button
               onClick={() => setIsDeleteModalOpen(true)}
               className="flex items-center gap-1.5 sm:gap-2 px-3 py-1.5 rounded-full text-xs font-medium transition-colors cursor-pointer border bg-white/5 text-red-400/80 border-white/10 hover:bg-red-500/10 hover:text-red-400"
@@ -923,10 +973,10 @@ export default function CollectionDetailClient({
             Add movies, TV shows, books, and anime to build your curated list.
           </p>
           {isOwner && (
-              <button
-                onClick={() => setIsSearchModalOpen(true)}
-                className="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-linear-to-br from-purple-500 to-pink-500 text-white font-semibold text-sm hover:brightness-110 transition-all cursor-pointer shadow-lg shadow-purple-500/25"
-              >
+            <button
+              onClick={() => setIsSearchModalOpen(true)}
+              className="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-linear-to-br from-purple-500 to-pink-500 text-white font-semibold text-sm hover:brightness-110 transition-all cursor-pointer shadow-lg shadow-purple-500/25"
+            >
               <Plus className="w-4 h-4" />
               Add Items
             </button>
@@ -948,6 +998,74 @@ export default function CollectionDetailClient({
         title={`Delete ${CRAVELIST_LABEL.toLowerCase()}?`}
         description={`Are you sure you want to delete "${collection.name}"? This cannot be undone.`}
       />
+
+      <Modal
+        isOpen={isPromoteModalOpen}
+        onClose={() => !isPromotingJourney && setIsPromoteModalOpen(false)}
+        maxSize="md"
+      >
+        <div className="pt-2">
+          <h3 className="text-lg font-semibold text-white mb-3">
+            Create journey from this list?
+          </h3>
+          {orderedItems.length > JOURNEY_MAX_ITEMS ? (
+            <p className="text-zinc-400 text-sm mb-6 leading-relaxed">
+              Journeys work best with up to {JOURNEY_MAX_ITEMS} items so each
+              transition feels meaningful. Craveo will select the best{" "}
+              {JOURNEY_MAX_ITEMS} from your {orderedItems.length} items to build
+              the most compelling arc, and explain its choices in the journey
+              description.
+            </p>
+          ) : (
+            <p className="text-zinc-400 text-sm mb-6 leading-relaxed">
+              We&apos;ll turn your {CRAVELIST_LABEL.toLowerCase()} into a guided
+              journey: Craveo will reorder your titles for the best viewing
+              sequence and add transitions between each step. You can only do
+              this once per list.
+            </p>
+          )}
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={() => setIsPromoteModalOpen(false)}
+              disabled={isPromotingJourney}
+              className="flex-1 py-2.5 rounded-xl font-medium text-zinc-300 hover:text-white hover:bg-white/5 transition-colors disabled:opacity-50 cursor-pointer"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={handleConfirmPromoteJourney}
+              className="flex-1 py-2.5 rounded-xl font-medium bg-purple-500 hover:bg-purple-600 text-white transition-colors flex items-center justify-center gap-2 cursor-pointer"
+            >
+              Create journey
+            </button>
+          </div>
+        </div>
+      </Modal>
+
+      {isPromotingJourney ? (
+        <div
+          className="fixed inset-0 z-120 flex flex-col items-center justify-center bg-black/70 backdrop-blur-sm px-6"
+          role="status"
+          aria-live="polite"
+          aria-label="Creating your journey"
+        >
+          <Loader2
+            className="w-12 h-12 animate-spin text-purple-400 mb-4"
+            aria-hidden
+          />
+          <p className="text-white text-lg md:text-2xl font-medium text-center">
+            Crafting your journey…
+          </p>
+          <p
+            key={promoteLoaderIndex}
+            className="text-zinc-400 text-md md:text-lg mt-2 text-center max-w-sm min-h-[2.75rem] px-2 animate-curate-text-fade"
+          >
+            {promoteLoaderMessage}
+          </p>
+        </div>
+      ) : null}
 
       {/* Review Modal */}
       <Modal

--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -157,6 +157,16 @@ export default async function CollectionDetailPage({
   };
   const savesCount = cloneCountResult.count ?? 0;
 
+  let linkedJourneyId: string | null = null;
+  if (isOwner) {
+    const { data: promotedJourney } = await supabase
+      .from("journeys")
+      .select("id")
+      .eq("source_collection_id", id)
+      .maybeSingle();
+    linkedJourneyId = promotedJourney?.id ?? null;
+  }
+
   return (
     <>
       <ViewTracker targetType="collection" targetId={id} />
@@ -180,6 +190,7 @@ export default async function CollectionDetailPage({
       }
       contentStats={contentStats}
       savesCount={savesCount}
+      linkedJourneyId={linkedJourneyId}
     />
     </>
   );

--- a/src/app/collections/new/page.tsx
+++ b/src/app/collections/new/page.tsx
@@ -20,10 +20,15 @@ import {
   ChevronDown,
 } from "lucide-react";
 import { createCollectionWithItems } from "@/app/actions/collection";
+import { promoteCollectionToJourney } from "@/app/actions/journey";
 import { EnrichedRecommendation } from "@/lib/types";
 import MediaSearchModal from "@/components/MediaSearchModal";
 import Papa from "papaparse";
 import Toast from "@/components/Toast";
+import Modal from "@/components/Modal";
+import { JOURNEY_MAX_ITEMS } from "@/config/journey";
+import { JOURNEY_CURATING_MESSAGES } from "@/config/curating-loader-messages";
+import { useRotatingCuratingMessage } from "@/hooks/useRotatingCuratingMessage";
 import {
   DndContext,
   closestCenter,
@@ -256,6 +261,12 @@ function CreateCollectionContent() {
   // Mobile: keep list panel open by default; tuck form behind details accordion
   const [mobileDetailsOpen, setMobileDetailsOpen] = useState(false);
   const [mobileListOpen, setMobileListOpen] = useState(true);
+  const [isPromoteModalOpen, setIsPromoteModalOpen] = useState(false);
+  const [isPromotingJourney, setIsPromotingJourney] = useState(false);
+  const { message: promoteLoaderMessage, index: promoteLoaderIndex } =
+    useRotatingCuratingMessage(JOURNEY_CURATING_MESSAGES, {
+      active: isPromotingJourney,
+    });
 
   // Persist draft to localStorage on every meaningful change
   useEffect(() => {
@@ -413,6 +424,24 @@ function CreateCollectionContent() {
         if (fileInputRef.current) fileInputRef.current.value = "";
       },
     });
+  };
+
+  const handleConfirmPromoteJourney = async () => {
+    if (!savedCollectionId) return;
+    setIsPromoteModalOpen(false);
+    setIsPromotingJourney(true);
+    try {
+      const result = await promoteCollectionToJourney(savedCollectionId);
+      if (result.error) {
+        setToastMessage(result.error);
+        return;
+      }
+      if (result.journeyId) {
+        router.push(`/journey/${result.journeyId}`);
+      }
+    } finally {
+      setIsPromotingJourney(false);
+    }
   };
 
   const handleSave = async () => {
@@ -647,15 +676,28 @@ function CreateCollectionContent() {
           </div>
 
           {/* Action buttons — desktop only (under form) */}
-          <div className="hidden lg:flex flex-col sm:flex-row gap-3 pt-2">
+          <div className="hidden lg:flex flex-col gap-3 pt-2">
             {savedCollectionId ? (
-              <Link
-                href={`/collections/${savedCollectionId}`}
-                className="flex-1 order-1 sm:order-2 px-6 py-2.5 flex items-center justify-center gap-2 rounded-xl text-sm font-medium bg-purple-500 hover:bg-purple-600 text-white transition-colors shadow-lg shadow-purple-500/20 cursor-pointer"
-              >
-                View {CRAVELIST_LABEL}
-              </Link>
-            ) : (
+              <div className="flex flex-col sm:flex-row gap-3">
+                <Link
+                  href={`/collections/${savedCollectionId}`}
+                  className="flex-1 px-6 py-2.5 flex items-center justify-center gap-2 rounded-xl text-sm font-medium bg-purple-500 hover:bg-purple-600 text-white transition-colors shadow-lg shadow-purple-500/20 cursor-pointer"
+                >
+                  View {CRAVELIST_LABEL}
+                </Link>
+                {items.length > 0 ? (
+                  <button
+                    type="button"
+                    onClick={() => setIsPromoteModalOpen(true)}
+                    className="flex-1 px-6 py-2.5 flex items-center justify-center gap-2 rounded-xl text-sm font-medium border border-purple-500/50 text-purple-300 bg-purple-500/10 hover:bg-purple-500/20 transition-colors cursor-pointer"
+                  >
+                    <ListOrdered className="w-4 h-4" />
+                    Create Journey from this
+                  </button>
+                ) : null}
+              </div>
+            ) : null}
+            {!savedCollectionId ? (
               <button
                 onClick={handleSave}
                 disabled={!name.trim() || isSubmitting}
@@ -667,7 +709,7 @@ function CreateCollectionContent() {
                   <span>Save {CRAVELIST_LABEL}</span>
                 )}
               </button>
-            )}
+            ) : null}
             <button
               onClick={() => router.back()}
               disabled={isSubmitting}
@@ -821,12 +863,24 @@ function CreateCollectionContent() {
 
           <div className="flex lg:hidden flex-col gap-2">
             {savedCollectionId ? (
-              <Link
-                href={`/collections/${savedCollectionId}`}
-                className="w-full px-6 py-2.5 flex items-center justify-center gap-2 rounded-xl text-sm font-medium bg-purple-500 hover:bg-purple-600 text-white transition-colors shadow-lg shadow-purple-500/20 cursor-pointer"
-              >
-                View {CRAVELIST_LABEL}
-              </Link>
+              <>
+                <Link
+                  href={`/collections/${savedCollectionId}`}
+                  className="w-full px-6 py-2.5 flex items-center justify-center gap-2 rounded-xl text-sm font-medium bg-purple-500 hover:bg-purple-600 text-white transition-colors shadow-lg shadow-purple-500/20 cursor-pointer"
+                >
+                  View {CRAVELIST_LABEL}
+                </Link>
+                {items.length > 0 ? (
+                  <button
+                    type="button"
+                    onClick={() => setIsPromoteModalOpen(true)}
+                    className="w-full px-6 py-2.5 flex items-center justify-center gap-2 rounded-xl text-sm font-medium border border-purple-500/50 text-purple-300 bg-purple-500/10 hover:bg-purple-500/20 transition-colors cursor-pointer"
+                  >
+                    <ListOrdered className="w-4 h-4" />
+                    Create Journey from this
+                  </button>
+                ) : null}
+              </>
             ) : (
               <button
                 onClick={handleSave}
@@ -857,6 +911,74 @@ function CreateCollectionContent() {
         onSelect={handleAddItem}
         onAddClick={handleAddItem}
       />
+
+      <Modal
+        isOpen={isPromoteModalOpen}
+        onClose={() => !isPromotingJourney && setIsPromoteModalOpen(false)}
+        maxSize="md"
+      >
+        <div className="pt-2">
+          <h3 className="text-lg font-semibold text-white mb-3">
+            Create journey from this list?
+          </h3>
+          {items.length > JOURNEY_MAX_ITEMS ? (
+            <p className="text-zinc-400 text-sm mb-6 leading-relaxed">
+              Journeys work best with up to {JOURNEY_MAX_ITEMS} items so each
+              transition feels meaningful. Craveo will select the best{" "}
+              {JOURNEY_MAX_ITEMS} from your {items.length} items to build the
+              most compelling arc, and explain its choices in the journey
+              description.
+            </p>
+          ) : (
+            <p className="text-zinc-400 text-sm mb-6 leading-relaxed">
+              We&apos;ll turn your {CRAVELIST_LABEL.toLowerCase()} into a guided
+              journey: Craveo will reorder your titles for the best viewing
+              sequence and add transitions between each step. You can only do this
+              once per list.
+            </p>
+          )}
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={() => setIsPromoteModalOpen(false)}
+              disabled={isPromotingJourney}
+              className="flex-1 py-2.5 rounded-xl font-medium text-zinc-300 hover:text-white hover:bg-white/5 transition-colors disabled:opacity-50 cursor-pointer"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={handleConfirmPromoteJourney}
+              className="flex-1 py-2.5 rounded-xl font-medium bg-purple-500 hover:bg-purple-600 text-white transition-colors cursor-pointer"
+            >
+              Create journey
+            </button>
+          </div>
+        </div>
+      </Modal>
+
+      {isPromotingJourney ? (
+        <div
+          className="fixed inset-0 z-120 flex flex-col items-center justify-center bg-black/70 backdrop-blur-sm px-6"
+          role="status"
+          aria-live="polite"
+          aria-label="Creating your journey"
+        >
+          <Loader2
+            className="w-12 h-12 animate-spin text-purple-400 mb-4"
+            aria-hidden
+          />
+          <p className="text-white text-lg font-medium text-center">
+            Crafting your journey…
+          </p>
+          <p
+            key={promoteLoaderIndex}
+            className="text-zinc-400 text-sm mt-2 text-center max-w-sm min-h-[2.75rem] px-2 animate-curate-text-fade"
+          >
+            {promoteLoaderMessage}
+          </p>
+        </div>
+      ) : null}
 
       <Toast message={toastMessage} onClose={() => setToastMessage(null)} />
     </main>

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -457,7 +457,7 @@ function SearchContent() {
                 <h2 className="text-2xl md:text-3xl font-bold tracking-tight mb-3">
                   {results.collectionTitle}
                 </h2>
-                <p className="text-sm text-purple-300/80 mb-2 flex items-center gap-1.5">
+                <p className="text-md md:text-lg text-purple-300/80 mb-2 flex items-center gap-1.5">
                   {results.collectionDescription}
                 </p>
                 <div className="flex flex-wrap items-center gap-3 mb-4">
@@ -528,10 +528,10 @@ function SearchContent() {
                 </div>
                 <div className="mt-4">
                   <RefineBar
-                  onRefine={handleRefine}
-                  onRefresh={handleRefresh}
-                  isLoading={isLoading}
-                />
+                    onRefine={handleRefine}
+                    onRefresh={handleRefresh}
+                    isLoading={isLoading}
+                  />
                 </div>
               </aside>
 

--- a/src/components/CuratingLoader.tsx
+++ b/src/components/CuratingLoader.tsx
@@ -1,94 +1,18 @@
 "use client";
 
-import { useState, useEffect, useMemo } from "react";
+import { useMemo, useEffect } from "react";
 import type { ContentType } from "@/lib/types";
 import { motion } from "framer-motion";
 import { usePrefersReducedMotion } from "@/hooks/usePrefersReducedMotion";
-
-const JOURNEY_MESSAGES = [
-  "Plotting your path through the cosmos...",
-  "Mapping the route from start to finish...",
-  "Weaving your story, one step at a time...",
-  "Sit back—we're crafting your adventure...",
-  "Connecting the dots for your perfect journey...",
-  "Designing the sequence of your dreams...",
-  "Charting your course through the stars...",
-  "Building the roadmap to your next obsession...",
-];
-
-const MEDIA_SPECIFIC_MESSAGES = {
-  movie: [
-    "Dimming the lights for your private screening...",
-    "Scanning the archives for a cinematic masterpiece...",
-    "Casting the leads for your next favorite film...",
-    "Reviewing the dailies to find the perfect pick...",
-    "Wait for it... the opening credits are starting...",
-    "Sifting through the reels for a hidden gem...",
-    "Adjusting the lens for your next big adventure...",
-    "Scouting locations for a story you'll love...",
-  ],
-  tv: [
-    "Cueing up your next great binge-watch...",
-    "Synchronizing with the latest season's best...",
-    "Checking the schedule for your next obsession...",
-    "Buffering the best plot twists just for you...",
-    "Setting the stage for a marathon-worthy series...",
-    "Scanning the airwaves for your perfect signal...",
-    "Drafting the pilot for your new favorite show...",
-    "Ensuring the cliffhanger is worth the wait...",
-  ],
-  book: [
-    "Cracking the spine on a new journey...",
-    "Leafing through the shelves for a page-turner...",
-    "Dusting off the classics and the bestsellers...",
-    "Finding the perfect chapter to get lost in...",
-    "Scouring the library for your next great read...",
-    "Inking the pages of your upcoming adventure...",
-    "Bookmark found. Fetching your next story...",
-    "Translating your mood into a literary escape...",
-  ],
-  anime: [
-    "Powering up the search to over 9000...",
-    "Syncing the subtitles for your next watch...",
-    "Sketching the frames of a new world...",
-    "Opening the portal to your next isekai...",
-    "Calibrating the spirit energy for your picks...",
-    "Scanning the multiverse for top-tier animation...",
-    "Choosing a story with a legendary soundtrack...",
-    "Rendering the masterpiece you’ve been waiting for...",
-  ],
-};
-
-type MediaTypeKey = keyof typeof MEDIA_SPECIFIC_MESSAGES;
+import {
+  JOURNEY_CURATING_MESSAGES,
+  getCuratingMessagesForMediaType,
+} from "@/config/curating-loader-messages";
+import { useRotatingCuratingMessage } from "@/hooks/useRotatingCuratingMessage";
 
 interface CuratingLoaderProps {
   mode?: "list" | "journey";
   mediaType?: ContentType | ContentType[];
-}
-
-function randomIndex(length: number, exclude?: number): number {
-  if (length <= 1) return 0;
-  let idx = Math.floor(Math.random() * length);
-  if (exclude !== undefined && idx === exclude) {
-    idx = (idx + 1) % length;
-  }
-  return idx;
-}
-
-function getMessagesForMediaType(
-  mediaType: ContentType | ContentType[] | undefined,
-): string[] {
-  if (!mediaType || mediaType === "all") {
-    return (Object.values(MEDIA_SPECIFIC_MESSAGES) as string[][]).flat();
-  }
-  const keys = Array.isArray(mediaType) ? mediaType : [mediaType];
-  if (keys.includes("all")) {
-    return (Object.values(MEDIA_SPECIFIC_MESSAGES) as string[][]).flat();
-  }
-  const merged = keys.flatMap(
-    (k) => MEDIA_SPECIFIC_MESSAGES[k as MediaTypeKey] ?? [],
-  );
-  return merged.length > 0 ? merged : getMessagesForMediaType("all");
 }
 
 export default function CuratingLoader({
@@ -99,18 +23,13 @@ export default function CuratingLoader({
   const messages = useMemo(
     () =>
       mode === "journey"
-        ? JOURNEY_MESSAGES
-        : getMessagesForMediaType(mediaType),
+        ? JOURNEY_CURATING_MESSAGES
+        : getCuratingMessagesForMediaType(mediaType),
     [mode, mediaType],
   );
-  const [index, setIndex] = useState(() => randomIndex(messages.length));
-
-  useEffect(() => {
-    const id = setInterval(() => {
-      setIndex((i) => randomIndex(messages.length, i));
-    }, 2800);
-    return () => clearInterval(id);
-  }, [messages.length]);
+  const { message, index } = useRotatingCuratingMessage(messages, {
+    active: true,
+  });
 
   // Lock body scroll when loader is active
   useEffect(() => {
@@ -247,9 +166,9 @@ export default function CuratingLoader({
       <div className="relative z-10 text-center">
         <p
           key={index}
-          className="text-2xl sm:text-3xl font-bold md:font-extrabold text-transparent bg-clip-text bg-gradient-to-r from-white via-white/90 to-white/70 animate-curate-text-fade drop-shadow-lg"
+          className="text-2xl sm:text-3xl font-bold md:font-extrabold text-transparent bg-clip-text bg-linear-to-r from-white via-white/90 to-white/70 animate-curate-text-fade drop-shadow-lg"
         >
-          {messages[Math.min(index, messages.length - 1)]}
+          {message}
         </p>
       </div>
     </motion.div>

--- a/src/components/IntentRefineStep.tsx
+++ b/src/components/IntentRefineStep.tsx
@@ -847,7 +847,7 @@ export default function IntentRefineStep({
   }
 
   /* ─── AI-generated questions ───────────────────────────────────────── */
-  if (!currentQuestion) return null;
+  if (!currentQuestion || !Array.isArray(currentQuestion.options) || currentQuestion.options.length === 0) return null;
 
   // Total progress dots = all questions across all visible rounds
   const progressDotCount = totalQuestions;

--- a/src/components/JourneyPath.tsx
+++ b/src/components/JourneyPath.tsx
@@ -90,7 +90,8 @@ export default function JourneyPath({
   const { getProgressForJourney, markWatched: markWatchedLocal } =
     useJourneyProgress(journeyId);
 
-  const isSavedJourney = UUID_REGEX.test(journeyId) && initialProgress !== undefined;
+  const isSavedJourney =
+    UUID_REGEX.test(journeyId) && initialProgress !== undefined;
 
   const [localProgress, setLocalProgress] = useState<{
     completed: Set<number>;
@@ -106,19 +107,22 @@ export default function JourneyPath({
     return { completed: new Set(), currentPosition: 1 };
   });
 
-  const progress = isSavedJourney && localProgress
-    ? localProgress
-    : {
-        completed: new Set(getProgressForJourney(journeyId).completed),
-        currentPosition: getProgressForJourney(journeyId).currentPosition,
-      };
+  const progress =
+    isSavedJourney && localProgress
+      ? localProgress
+      : {
+          completed: new Set(getProgressForJourney(journeyId).completed),
+          currentPosition: getProgressForJourney(journeyId).currentPosition,
+        };
 
-  const currentPosition = isSavedJourney && localProgress
-    ? localProgress.currentPosition
-    : getProgressForJourney(journeyId).currentPosition;
-  const completed = isSavedJourney && localProgress
-    ? localProgress.completed
-    : new Set(getProgressForJourney(journeyId).completed);
+  const currentPosition =
+    isSavedJourney && localProgress
+      ? localProgress.currentPosition
+      : getProgressForJourney(journeyId).currentPosition;
+  const completed =
+    isSavedJourney && localProgress
+      ? localProgress.completed
+      : new Set(getProgressForJourney(journeyId).completed);
 
   const [showActionsFor, setShowActionsFor] = useState<number | null>(null);
   const [markError, setMarkError] = useState<string | null>(null);
@@ -157,10 +161,14 @@ export default function JourneyPath({
   const handleSaveItemReview = useCallback(async () => {
     if (reviewItemPosition == null) return;
     setIsSavingItemReview(true);
-    const result = await updateJourneyItemReview(journeyId, reviewItemPosition, {
-      rating: reviewRating || undefined,
-      review: reviewText.trim() || undefined,
-    });
+    const result = await updateJourneyItemReview(
+      journeyId,
+      reviewItemPosition,
+      {
+        rating: reviewRating || undefined,
+        review: reviewText.trim() || undefined,
+      },
+    );
     setIsSavingItemReview(false);
     if (!result.error) {
       setReviewItemPosition(null);
@@ -295,24 +303,22 @@ export default function JourneyPath({
             </div>
           )}
 
-          {isOwner &&
-            isSavedJourney &&
-            journeyStatus === "completed" && (
-              <button
-                onClick={() => setShowJourneyReviewModal(true)}
-                className="mb-4 w-full flex items-center justify-center gap-2 py-2.5 px-4 rounded-xl bg-amber-500/20 text-amber-400 hover:bg-amber-500/30 border border-amber-500/30 transition-colors cursor-pointer"
-              >
-                <Star className="w-4 h-4" />
-                {journeyReviewData?.reviewText || journeyReviewData?.overallRating
-                  ? "Edit journey review"
-                  : "Add journey review"}
-              </button>
-            )}
+          {isOwner && isSavedJourney && journeyStatus === "completed" && (
+            <button
+              onClick={() => setShowJourneyReviewModal(true)}
+              className="mb-4 w-full flex items-center justify-center gap-2 py-2.5 px-4 rounded-xl bg-amber-500/20 text-amber-400 hover:bg-amber-500/30 border border-amber-500/30 transition-colors cursor-pointer"
+            >
+              <Star className="w-4 h-4" />
+              {journeyReviewData?.reviewText || journeyReviewData?.overallRating
+                ? "Edit journey review"
+                : "Add journey review"}
+            </button>
+          )}
 
           <h2 className="text-2xl md:text-3xl font-bold tracking-tight mb-3">
             {journey.journeyTitle}
           </h2>
-          <p className="text-sm text-purple-300/80 mb-4">
+          <p className="text-md md:text-lg text-purple-300/80 mb-4">
             {journey.description}
           </p>
           <div className="flex flex-wrap items-center gap-3 mb-4">
@@ -337,7 +343,7 @@ export default function JourneyPath({
               forkedCount > 0) && (
               <span className="text-sm text-zinc-500">
                 {(contentStats?.favorites_count ?? 0) > 0 && (
-                  <span>{(contentStats?.favorites_count ?? 0)} ♥</span>
+                  <span>{contentStats?.favorites_count ?? 0} ♥</span>
                 )}
                 {(contentStats?.favorites_count ?? 0) > 0 &&
                   ((contentStats?.views_count ?? 0) > 0 || forkedCount > 0) && (
@@ -351,9 +357,7 @@ export default function JourneyPath({
                 {(contentStats?.views_count ?? 0) > 0 && forkedCount > 0 && (
                   <span className="mx-1">·</span>
                 )}
-                {forkedCount > 0 && (
-                  <span>{forkedCount} saved</span>
-                )}
+                {forkedCount > 0 && <span>{forkedCount} saved</span>}
               </span>
             )}
           </div>
@@ -602,10 +606,14 @@ export default function JourneyPath({
               disabled={isSavingItemReview}
               className="w-full bg-black/50 border border-white/10 rounded-lg px-4 py-3 text-white placeholder-zinc-500 focus:border-purple-500 focus:outline-none resize-none disabled:opacity-50 mb-4"
             />
-            <p className="text-zinc-500 text-xs mb-4">{reviewText.length}/280</p>
+            <p className="text-zinc-500 text-xs mb-4">
+              {reviewText.length}/280
+            </p>
             <div className="flex gap-2">
               <button
-                onClick={() => !isSavingItemReview && setReviewItemPosition(null)}
+                onClick={() =>
+                  !isSavingItemReview && setReviewItemPosition(null)
+                }
                 disabled={isSavingItemReview}
                 className="flex-1 py-2.5 rounded-xl font-medium text-zinc-300 hover:text-white hover:bg-white/5 transition-colors disabled:opacity-50"
               >
@@ -631,7 +639,9 @@ export default function JourneyPath({
       {/* Journey review modal (when completed) */}
       <Modal
         isOpen={showJourneyReviewModal}
-        onClose={() => !isSavingJourneyReview && setShowJourneyReviewModal(false)}
+        onClose={() =>
+          !isSavingJourneyReview && setShowJourneyReviewModal(false)
+        }
         maxSize="md"
       >
         <div className="pt-2">
@@ -681,9 +691,7 @@ export default function JourneyPath({
           </div>
           <textarea
             value={journeyReviewText}
-            onChange={(e) =>
-              setJourneyReviewText(e.target.value.slice(0, 280))
-            }
+            onChange={(e) => setJourneyReviewText(e.target.value.slice(0, 280))}
             placeholder="Add a short review of the journey (optional)"
             rows={3}
             maxLength={280}

--- a/src/config/curating-loader-messages.ts
+++ b/src/config/curating-loader-messages.ts
@@ -1,0 +1,91 @@
+import type { ContentType } from "@/lib/types";
+
+/** Journey mode — same copy as Ask / search when curating a path */
+export const JOURNEY_CURATING_MESSAGES = [
+  "Plotting your path through the cosmos...",
+  "Mapping the route from start to finish...",
+  "Weaving your story, one step at a time...",
+  "Sit back—we're crafting your adventure...",
+  "Connecting the dots for your perfect journey...",
+  "Designing the sequence of your dreams...",
+  "Charting your course through the stars...",
+  "Building the roadmap to your next obsession...",
+] as const;
+
+export const MEDIA_SPECIFIC_CURATING_MESSAGES = {
+  movie: [
+    "Dimming the lights for your private screening...",
+    "Scanning the archives for a cinematic masterpiece...",
+    "Casting the leads for your next favorite film...",
+    "Reviewing the dailies to find the perfect pick...",
+    "Wait for it... the opening credits are starting...",
+    "Sifting through the reels for a hidden gem...",
+    "Adjusting the lens for your next big adventure...",
+    "Scouting locations for a story you'll love...",
+  ],
+  tv: [
+    "Cueing up your next great binge-watch...",
+    "Synchronizing with the latest season's best...",
+    "Checking the schedule for your next obsession...",
+    "Buffering the best plot twists just for you...",
+    "Setting the stage for a marathon-worthy series...",
+    "Scanning the airwaves for your perfect signal...",
+    "Drafting the pilot for your new favorite show...",
+    "Ensuring the cliffhanger is worth the wait...",
+  ],
+  book: [
+    "Cracking the spine on a new journey...",
+    "Leafing through the shelves for a page-turner...",
+    "Dusting off the classics and the bestsellers...",
+    "Finding the perfect chapter to get lost in...",
+    "Scouring the library for your next great read...",
+    "Inking the pages of your upcoming adventure...",
+    "Bookmark found. Fetching your next story...",
+    "Translating your mood into a literary escape...",
+  ],
+  anime: [
+    "Powering up the search to over 9000...",
+    "Syncing the subtitles for your next watch...",
+    "Sketching the frames of a new world...",
+    "Opening the portal to your next isekai...",
+    "Calibrating the spirit energy for your picks...",
+    "Scanning the multiverse for top-tier animation...",
+    "Choosing a story with a legendary soundtrack...",
+    "Rendering the masterpiece you've been waiting for...",
+  ],
+} as const;
+
+type MediaTypeKey = keyof typeof MEDIA_SPECIFIC_CURATING_MESSAGES;
+
+export function randomCuratingIndex(
+  length: number,
+  exclude?: number,
+): number {
+  if (length <= 1) return 0;
+  let idx = Math.floor(Math.random() * length);
+  if (exclude !== undefined && idx === exclude) {
+    idx = (idx + 1) % length;
+  }
+  return idx;
+}
+
+export function getCuratingMessagesForMediaType(
+  mediaType: ContentType | ContentType[] | undefined,
+): string[] {
+  const allMessages = (): string[] =>
+    Object.values(MEDIA_SPECIFIC_CURATING_MESSAGES).flatMap((arr) => [...arr]);
+
+  if (!mediaType || mediaType === "all") {
+    return allMessages();
+  }
+  const keys = Array.isArray(mediaType) ? mediaType : [mediaType];
+  if (keys.includes("all")) {
+    return allMessages();
+  }
+  const merged = keys.flatMap(
+    (k) => MEDIA_SPECIFIC_CURATING_MESSAGES[k as MediaTypeKey] ?? [],
+  );
+  return merged.length > 0
+    ? merged
+    : getCuratingMessagesForMediaType("all");
+}

--- a/src/config/journey.ts
+++ b/src/config/journey.ts
@@ -1,0 +1,2 @@
+/** Max items in a journey when promoting from a collection (AI may select this many from larger lists). */
+export const JOURNEY_MAX_ITEMS = 10;

--- a/src/hooks/useIntentRefine.ts
+++ b/src/hooks/useIntentRefine.ts
@@ -10,6 +10,18 @@ import {
 
 export type RefineStep = "idle" | "loading" | "questions" | "complete";
 
+function sanitizeQuestions(raw: RefineQuestion[]): RefineQuestion[] {
+  if (!Array.isArray(raw)) return [];
+  return raw.filter(
+    (q) =>
+      q &&
+      typeof q.id === "string" &&
+      typeof q.text === "string" &&
+      Array.isArray(q.options) &&
+      q.options.length > 0,
+  );
+}
+
 export function useIntentRefine() {
   const [step, setStep] = useState<RefineStep>("idle");
   const [questions, setQuestions] = useState<RefineQuestion[]>([]);
@@ -65,8 +77,14 @@ export function useIntentRefine() {
           setRefinedQuery(result.refinedQuery);
           setStep("complete");
         } else {
-          setQuestions(result.questions);
-          setStep("questions");
+          const valid = sanitizeQuestions(result.questions);
+          if (valid.length === 0) {
+            setError("Received invalid follow-up questions. Please try again.");
+            setStep("idle");
+          } else {
+            setQuestions(valid);
+            setStep("questions");
+          }
         }
       }
     },
@@ -90,8 +108,14 @@ export function useIntentRefine() {
           setRefinedQuery(result.refinedQuery);
           setStep("complete");
         } else {
-          setQuestions(result.questions);
-          setStep("questions");
+          const valid = sanitizeQuestions(result.questions);
+          if (valid.length === 0) {
+            setError("Received invalid follow-up questions. Please try again.");
+            setStep("idle");
+          } else {
+            setQuestions(valid);
+            setStep("questions");
+          }
         }
       }
     },

--- a/src/hooks/useRotatingCuratingMessage.ts
+++ b/src/hooks/useRotatingCuratingMessage.ts
@@ -1,0 +1,44 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { randomCuratingIndex } from "@/config/curating-loader-messages";
+
+const DEFAULT_INTERVAL_MS = 2800;
+
+/**
+ * Cycles through predefined loader lines (same timing as CuratingLoader).
+ * When `active` is false, the interval is cleared (e.g. overlay hidden).
+ */
+export function useRotatingCuratingMessage(
+  messages: readonly string[],
+  options?: { intervalMs?: number; active?: boolean },
+): { message: string; index: number } {
+  const intervalMs = options?.intervalMs ?? DEFAULT_INTERVAL_MS;
+  const active = options?.active ?? true;
+
+  const [index, setIndex] = useState(0);
+
+  useEffect(() => {
+    if (!active) return;
+    if (messages.length === 0) {
+      setIndex(0);
+      return;
+    }
+    if (messages.length === 1) {
+      setIndex(0);
+      return;
+    }
+    setIndex(randomCuratingIndex(messages.length));
+    const id = setInterval(() => {
+      setIndex((i) => randomCuratingIndex(messages.length, i));
+    }, intervalMs);
+    return () => clearInterval(id);
+  }, [active, messages.length, intervalMs]);
+
+  const safeIdx =
+    messages.length === 0 ? 0 : Math.min(index, messages.length - 1);
+  return {
+    message: messages[safeIdx] ?? "",
+    index: safeIdx,
+  };
+}

--- a/src/lib/ai-anthropic.ts
+++ b/src/lib/ai-anthropic.ts
@@ -3,11 +3,16 @@ import {
   AIResponse,
   ContentType,
   JourneyAIResponse,
+  PromoteItem,
   RefineAnswer,
   RefineResponse,
 } from "./types";
 import { getSystemPrompt } from "./ai-prompts";
-import { getJourneySystemPrompt } from "./ai-journey-prompts";
+import {
+  buildJourneyFromListUserMessage,
+  getJourneyFromListPrompt,
+  getJourneySystemPrompt,
+} from "./ai-journey-prompts";
 import { getRefineSystemPrompt } from "./ai-refine-prompts";
 import { cleanAndParseJSON } from "./ai-utils";
 
@@ -29,7 +34,7 @@ export async function generateWithAnthropic(
   }
 
   const client = new Anthropic({ apiKey });
-  const model = process.env.CLAUDE_MODEL || "claude-haiku-4-5-20251001";
+  const model = process.env.CLAUDE_MODEL || "claude-sonnet-4-20250514";
 
   const message = await client.messages.create({
     model,
@@ -69,7 +74,7 @@ export async function generateJourneyWithAnthropic(
   }
 
   const client = new Anthropic({ apiKey });
-  const model = process.env.CLAUDE_MODEL || "claude-haiku-4-5-20251001";
+  const model = process.env.CLAUDE_MODEL || "claude-sonnet-4-20250514";
 
   const message = await client.messages.create({
     model,
@@ -81,6 +86,53 @@ export async function generateJourneyWithAnthropic(
       streamingServiceOnly: options.streamingServiceOnly,
     }),
     messages: [{ role: "user", content: query }],
+  });
+
+  const textBlock = message.content.find((block) => block.type === "text");
+  if (textBlock?.type !== "text") {
+    throw new Error("No text response from Claude");
+  }
+
+  return cleanAndParseJSON<JourneyAIResponse>(textBlock.text);
+}
+
+export async function generateJourneyFromListWithAnthropic(
+  items: PromoteItem[],
+  type: ContentType | ContentType[],
+  options: {
+    collectionName: string;
+    collectionDescription?: string | null;
+    maxItems?: number;
+    userContext?: import("./types").UserRecommendContext;
+    maxOutputTokens?: number;
+    temperature?: number;
+    responseMimeType?: string;
+  },
+): Promise<JourneyAIResponse> {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    throw new Error("ANTHROPIC_API_KEY is required for Anthropic provider");
+  }
+
+  const client = new Anthropic({ apiKey });
+  const model = process.env.CLAUDE_MODEL || "claude-sonnet-4-20250514";
+
+  const userMessage = buildJourneyFromListUserMessage(
+    items,
+    options.collectionName,
+    options.collectionDescription,
+  );
+
+  const message = await client.messages.create({
+    model,
+    max_tokens: options.maxOutputTokens || 6000,
+    temperature: options.temperature ?? 0.7,
+    system: getJourneyFromListPrompt(type, {
+      maxItems: options.maxItems,
+      userContext: options.userContext,
+      inputItemCount: items.length,
+    }),
+    messages: [{ role: "user", content: userMessage }],
   });
 
   const textBlock = message.content.find((block) => block.type === "text");
@@ -106,7 +158,7 @@ export async function generateRefineWithAnthropic(
   }
 
   const client = new Anthropic({ apiKey });
-  const model = process.env.CLAUDE_MODEL || "claude-haiku-4-5-20251001";
+  const model = process.env.CLAUDE_MODEL || "claude-sonnet-4-20250514";
 
   const message = await client.messages.create({
     model,

--- a/src/lib/ai-gemini.ts
+++ b/src/lib/ai-gemini.ts
@@ -3,11 +3,16 @@ import {
   AIResponse,
   ContentType,
   JourneyAIResponse,
+  PromoteItem,
   RefineAnswer,
   RefineResponse,
 } from "./types";
 import { getSystemPrompt } from "./ai-prompts";
-import { getJourneySystemPrompt } from "./ai-journey-prompts";
+import {
+  buildJourneyFromListUserMessage,
+  getJourneyFromListPrompt,
+  getJourneySystemPrompt,
+} from "./ai-journey-prompts";
 import { getRefineSystemPrompt } from "./ai-refine-prompts";
 import { cleanAndParseJSON } from "./ai-utils";
 
@@ -97,6 +102,56 @@ export async function generateJourneyWithGemini(
   return cleanAndParseJSON<JourneyAIResponse>(text);
 }
 
+export async function generateJourneyFromListWithGemini(
+  items: PromoteItem[],
+  type: ContentType | ContentType[],
+  options: {
+    collectionName: string;
+    collectionDescription?: string | null;
+    maxItems?: number;
+    userContext?: import("./types").UserRecommendContext;
+    maxOutputTokens?: number;
+    temperature?: number;
+    responseMimeType?: string;
+  },
+): Promise<JourneyAIResponse> {
+  const apiKey = process.env.GOOGLE_AI_API_KEY;
+  if (!apiKey) {
+    throw new Error("GOOGLE_AI_API_KEY is required for Gemini provider");
+  }
+
+  const model = process.env.GEMINI_MODEL || "gemini-2.0-flash";
+  const ai = new GoogleGenAI({ apiKey });
+
+  const userMessage = buildJourneyFromListUserMessage(
+    items,
+    options.collectionName,
+    options.collectionDescription,
+  );
+
+  const response = await ai.models.generateContent({
+    model,
+    contents: userMessage,
+    config: {
+      systemInstruction: getJourneyFromListPrompt(type, {
+        maxItems: options.maxItems,
+        userContext: options.userContext,
+        inputItemCount: items.length,
+      }),
+      maxOutputTokens: options.maxOutputTokens || 6000,
+      temperature: options.temperature ?? 0.4,
+      responseMimeType: options.responseMimeType || "application/json",
+    },
+  });
+
+  const text = response.text ?? "";
+  if (!text) {
+    throw new Error("No text response from Gemini");
+  }
+
+  return cleanAndParseJSON<JourneyAIResponse>(text);
+}
+
 export async function generateRefineWithGemini(
   query: string,
   type: ContentType | ContentType[],
@@ -125,6 +180,27 @@ export async function generateRefineWithGemini(
       maxOutputTokens: 2000,
       temperature: 0.8,
       responseMimeType: "application/json",
+      responseSchema: {
+        type: "object",
+        properties: {
+          questions: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                id: { type: "string" },
+                text: { type: "string" },
+                options: { type: "array", items: { type: "string" } },
+                multiSelect: { type: "boolean" },
+              },
+              required: ["id", "text", "options", "multiSelect"],
+            },
+          },
+          isComplete: { type: "boolean" },
+          refinedQuery: { type: "string", nullable: true },
+        },
+        required: ["questions", "isComplete"],
+      },
     },
   });
 

--- a/src/lib/ai-journey-prompts.ts
+++ b/src/lib/ai-journey-prompts.ts
@@ -1,5 +1,10 @@
-import { ContentType, UserRecommendContext } from "./types";
+import {
+  ContentType,
+  PromoteItem,
+  UserRecommendContext,
+} from "./types";
 import { ENABLED_MEDIA_TYPES, getTypeLabel } from "@/config/media-types";
+import { JOURNEY_MAX_ITEMS } from "@/config/journey";
 
 function getTypeFieldRule(): string {
   const types = ENABLED_MEDIA_TYPES.map((t) => `"${t}"`).join(" or ");
@@ -139,37 +144,45 @@ export function getJourneySystemPrompt(
   const firstItemHook = getFirstItemHookGuidance(type);
   const typeSequencingHint = getTypeSequencingHint(type);
 
-  return `${userContextBlock}You are an expert media curator specializing in transformative ${typeLabel} experiences — journeys where each piece deepens the last and changes how the ${audience} sees the subject. By the end, the user should feel they've gone somewhere, not just consumed a list.
+  return `${userContextBlock}You are recommending a sequence of ${typeLabel} to someone you care about. Your goal is simple: each piece should make them feel something real, and by the end they should feel moved, satisfied, and eager to tell a friend about what they just experienced. Think like a thoughtful friend, not a film professor.
 
-Given a user's query, create a SEQUENCED journey of ${options?.excludeTitles && options.excludeTitles.length > 0 ? "10-12" : "6-8"} items that forms a coherent arc with emotional progression and a rewarding payoff.
+Given a user's query, create a SEQUENCED journey of ${options?.excludeTitles && options.excludeTitles.length > 0 ? "10-12" : "6-8"} items that flows naturally from start to finish — emotionally clear, genuinely enjoyable, and deeply satisfying.
 
-TRANSFORMATION & ANTICIPATION:
-- Design each journey so the user feels transformed by the end — not just entertained, but having gained new perspective or understanding.
-- The final 1–2 items must deliver a payoff: a culmination that makes the journey feel complete. Avoid anticlimactic endings.
-- Every "transitionToNext" must create anticipation: hint at what will shift in their understanding or feeling, not just describe the next title.
-- The journey "description" must sell the experience: what they'll feel/understand by the end, why this order matters, why it's unique. Avoid generic phrases like "you'll discover great films."
-- "whatYoullLearn": use specific, personal takeaways (e.g. "how directors use silence for tension", "why this ending works despite seeming ambiguous"), not vague terms like "cinematography" or "great acting."
-- Hidden gems: each must earn its place in the arc. Users should feel they discovered something special — not just lesser-known, but purposefully chosen for this sequence.${typeSequencingHint}
+EMOTIONAL FLOW (this is the heart of a good journey):
+- The sequence should feel like a conversation, not a curriculum. Each piece naturally leads to the next because of how it makes the ${audience} feel.
+- Start with something warm, inviting, and immediately engaging — something that makes the ${audience} think "oh, I'm going to love this."
+- Build emotional depth through the middle — the ${audience} should feel more invested with each step, never confused or lost.
+- End on something that feels like arriving somewhere good: uplifting, cathartic, or meaningfully moving. The ${audience} should want to share this journey, not recover from it. Never end on something bleak, ambiguous, or hollow.
+- If the journey touches heavy themes, always provide emotional relief or resolution before the end. Don't leave someone in a dark place.${typeSequencingHint}
+
+WHAT MAKES EACH ITEM MATTER:
+- Every title must earn its place by how it makes the ${audience} FEEL in context of this sequence — not because it's critically acclaimed or culturally important.
+- "description": Write like you're telling a friend why they'll love this one, right now, at this point in the journey. Tie it to the emotional moment, not to film theory.
+- "whatYoullLearn": Frame as a personal, relatable insight — what this will make them feel or realize about themselves, relationships, or the world. e.g. "you'll understand why letting go is sometimes the bravest thing" or "this will change how you see ordinary kindness." Never use academic language like "cinematography techniques" or "narrative structure."
+- "whyThisPosition": Explain the emotional logic — why does this feel right after the last one? What mood are they in, and why does this meet them there?
+- "transitionToNext": Acknowledge how the ${audience} likely feels right now, then explain why the next piece is exactly what they need next. Think emotional momentum — like a friend saying "and now you're ready for this." Not a cliffhanger, not an intellectual tease.
+- Prioritize titles that genuinely serve the emotional flow. Include well-known works when they're the right fit, and lesser-known ones only when they'll land harder in this sequence. Never include something obscure just for variety.
 
 CRITICAL REQUIREMENTS:
 1. HOOK IMMEDIATELY: ${firstItemHook}
-2. BUILD COMPLEXITY: Each item should prepare the ${audience} for the next
-3. EMOTIONAL ARC: Early items hook and intrigue; middle items deepen; final item(s) deliver payoff or revelation
-4. SHOW EVOLUTION: Include mix of eras/styles showing how the genre/topic developed. Include roughly 60% recognizable titles and 40% hidden gems
-5. TRANSITIONS CREATE ANTICIPATION: Every "transitionToNext" must be specific, insightful, and create curiosity for what comes next
+2. NATURAL MOMENTUM: Each item should feel like an obvious, satisfying "what's next" — the ${audience} should never wonder why something is here
+3. EMOTIONAL CLARITY: The ${audience} should always know where they are emotionally in the journey. No confusion, no jarring tonal shifts without purpose
+4. SATISFYING ENDING: The final item MUST leave the ${audience} feeling fulfilled — warm, hopeful, moved, or gently transformed. This is non-negotiable
+5. TRANSITIONS ARE EMOTIONAL HANDOFFS: Every "transitionToNext" must feel like a friend saying "trust me, you need this next"
 6. RESPECT CONSTRAINTS: If the user query specifies a rating (e.g., "> 8"), year, or date range (e.g. "2015+", "from the 90s"), popularity, or single-season/one-season/miniseries/limited series for TV, YOU MUST STRICTLY ADHERE TO IT. For single-season requests: ONLY include TV shows with exactly ONE season — no multi-season series. Every item's "year" must fall within any specified range.${typeMixHint}${streamingRule}${excludeRule}
 ${7 + excludeOffset}. QUALITY CONTROL: If the user query specifies "popular", "highly rated", or "high ratings", YOU MUST ONLY INCLUDE ITEMS WITH A MATURE CRITICAL CONSENSUS (e.g., IMDB > 7.5 or Rotten Tomatoes > 80%). Do not take risks on obscure or poorly rated titles for these requests.
-${8 + excludeOffset}. Return ONLY valid JSON, no markdown, no code fences, no explanation
-${9 + excludeOffset}. Keep journey_title SHORT: 3-6 words max (e.g. "Intro to Noir", "Sci-Fi Masterclass").${journeyTitleHint}
+${8 + excludeOffset}. NO GIMMICKS: Do NOT include titles just because they're critically acclaimed, thematically clever, or "important." Every pick must feel like it genuinely belongs in the emotional flow. No filler, no "you should watch this because it's a classic."
+${9 + excludeOffset}. Return ONLY valid JSON, no markdown, no code fences, no explanation
+${10 + excludeOffset}. Keep journey_title SHORT: 3-6 words max (e.g. "Finding Light in Darkness", "Love Against the Odds").${journeyTitleHint}
 ${typeFieldRule}
 ${onlyRecommendRule}
 
 Response format (use exact field names):
 {
-  "journey_title": "Short, punchy title (3-6 words)",
-  "description": "2-3 sentences that SELL the journey: what they'll feel/understand by the end, why this order matters, why it's unique. Be specific — no generic phrases.",
+  "journey_title": "Short, warm title (3-6 words)",
+  "description": "2-3 sentences telling the ${audience} what emotional experience awaits them. Write it like telling a friend: 'By the end of this, you'll feel [X].' Be honest and specific — no generic phrases like 'you'll discover great films.'",
   "total_runtime_minutes": 0,
-  "difficulty_progression": "e.g. accessible → challenging",
+  "difficulty_progression": "e.g. light & inviting → emotionally rich → deeply moving",
   "items": [
     {
       "position": 1,
@@ -177,19 +190,146 @@ Response format (use exact field names):
       "creator": "Director/Showrunner/Author name",
       "year": 2020,
       "type": "${exampleType}",
-      "description": "1-2 sentences tying concrete aspects (scene, theme, technique) to the query — avoid generic praise",
+      "description": "1-2 sentences: why a friend would love this right now, at this point in the journey. Speak to emotion, not technique.",
       "genres": ["Genre1", "Genre2"],
-      "whyThisPosition": "If position 1: why start here and why it hooks. Otherwise: why this comes after the previous",
-      "whatYoullLearn": "Specific, personal takeaway (e.g. how X uses Y for Z) — not vague terms",
+      "whyThisPosition": "The emotional logic: what mood is the ${audience} in after the previous, and why does this meet them there? For position 1: why this is the perfect welcoming start.",
+      "whatYoullLearn": "A personal, relatable insight — what this will make them feel or realize. e.g. 'you'll understand why vulnerability takes more courage than strength'",
       "keyThemes": ["theme1", "theme2", "theme3"],
       "difficultyLevel": "beginner",
       "ratingScore": 8.5,
       "popularityScore": 90,
-      "transitionToNext": "Create anticipation for the NEXT item: hint at what will shift in their understanding or feeling. Use null for the last item."
+      "transitionToNext": "How the ${audience} likely feels now + why the next piece is exactly what they need. Warm and inviting, not a cliffhanger. Use null for the last item."
     }
   ]
 }
 
-For "difficultyLevel" use exactly: "beginner" | "intermediate" | "advanced"
+For "difficultyLevel" use as emotional weight: "beginner" = lighter and accessible, "intermediate" = emotionally engaging with some complexity, "advanced" = intense or heavy. A good journey starts lighter and builds, but never overwhelms without relief.
 For "transitionToNext" use null for the last item, string for all others.`;
+}
+
+/** User message body for journey-from-list (serialized JSON). */
+export function buildJourneyFromListUserMessage(
+  items: PromoteItem[],
+  collectionName: string,
+  collectionDescription: string | null | undefined,
+): string {
+  const payload = {
+    collectionName,
+    collectionDescription: collectionDescription ?? null,
+    itemCount: items.length,
+    items: items.map((item, index) => ({
+      index: index + 1,
+      title: item.title,
+      year: item.year,
+      type: item.type,
+      genres: item.genres,
+      creator: item.creator ?? null,
+      description: item.description ?? null,
+    })),
+  };
+  return JSON.stringify(payload, null, 0);
+}
+
+export function getJourneyFromListPrompt(
+  type: ContentType | ContentType[],
+  options: {
+    maxItems?: number;
+    userContext?: UserRecommendContext;
+    inputItemCount: number;
+  },
+): string {
+  const maxItems = options.maxItems ?? JOURNEY_MAX_ITEMS;
+  const typeLabel = Array.isArray(type)
+    ? type.map((t) => getTypeLabel(t)).join(", ")
+    : getTypeLabel(type);
+
+  const typeFieldRule = getTypeFieldRule();
+  let onlyTypesRule = `- Each item's "type" must be one of the types present in the user's list (respect their actual types).`;
+  if (type !== "all" && !Array.isArray(type)) {
+    onlyTypesRule = `- ONLY include items where "type" is exactly: ${typeLabel}`;
+  } else if (Array.isArray(type) && !type.includes("all")) {
+    onlyTypesRule = `- ONLY include items where "type" is one of: ${typeLabel}`;
+  }
+
+  let exampleType: string = type === "all" ? "movie" : (type as string);
+  if (Array.isArray(type)) {
+    exampleType = type[0] ?? "movie";
+  }
+
+  const audience = getAudienceLanguage(type);
+  const firstItemHook = getFirstItemHookGuidance(type);
+  const typeSequencingHint = getTypeSequencingHint(type);
+  const userContextBlock = options.userContext
+    ? formatUserContextBlock(options.userContext)
+    : "";
+
+  const selectionRule =
+    options.inputItemCount > maxItems
+      ? `
+SELECTION (CRITICAL): The user provided ${options.inputItemCount} items but a journey may include at most ${maxItems} items.
+- Choose exactly ${maxItems} items from their list that form the strongest thematic/emotional arc.
+- In the journey "description", add 1–2 sentences explaining which titles you omitted and why (e.g. weaker fit for the arc, redundant theme, pacing).
+- Do NOT invent or add titles not in their list.`
+      : `
+The user provided ${options.inputItemCount} items. Include every item exactly once in your output (reorder only).`;
+
+  return `${userContextBlock}You are helping a friend turn their saved list (Cravelist) into a meaningful journey — same titles, but in an order that tells a story, builds emotion, and ends somewhere that feels deeply satisfying. Think like a thoughtful friend, not a curator writing liner notes.
+
+INPUT: You will receive JSON with collectionName, collectionDescription (optional), and items[] with title, year, type, genres, creator, description.
+
+STRICT RULES:
+- You MUST ONLY use titles from the provided items. Never add new works.
+- Reorder items into the best viewing/reading sequence for emotional flow and a satisfying ending.
+- Match each output item's "title", "year", and "type" to the corresponding work from the input (exact title spelling as given).
+${selectionRule}
+
+EMOTIONAL FLOW (this is the heart of a good journey):
+- Start with something warm, inviting, and immediately engaging — something that makes the ${audience} think "oh, I'm going to love this."
+- Build emotional depth through the middle. Each step should feel like a natural conversation — "now that you felt that, you're ready for this."
+- End on something that feels like arriving somewhere good: uplifting, cathartic, or meaningfully moving. The ${audience} should want to share this journey. Never end on something bleak, ambiguous, or hollow.
+- If the journey touches heavy themes, ensure there is emotional relief or resolution before the ending.
+- The journey "description" must tell the ${audience} what emotional experience awaits. Write it like you're talking to a friend: "By the end of this, you'll feel..." ${options.inputItemCount > maxItems ? "Also explain which titles were left out and why — be honest and kind about it." : ""}
+- Every "transitionToNext" should be an emotional handoff: acknowledge how they likely feel, then explain why the next piece is exactly what they need. Think "trust me, you need this next." Null only on the last item.
+- "whatYoullLearn" must be personal, relatable insights — what this will make them feel or realize. Never academic language.
+${typeSequencingHint}
+
+CRITICAL:
+1. HOOK: ${firstItemHook}
+2. SATISFYING ENDING: The final item MUST leave the ${audience} feeling fulfilled — warm, hopeful, moved, or gently transformed. This is non-negotiable.
+3. EMOTIONAL ARC: welcoming → deepening → resolution. The ${audience} should always know where they are emotionally.
+4. TRANSITIONS ARE EMOTIONAL HANDOFFS: warm and inviting, not cliffhangers or intellectual teases
+5. NO GIMMICKS: Every pick must earn its place through genuine emotional fit. No title is here "because it's a classic" — only because it belongs in this sequence.
+6. Return ONLY valid JSON — no markdown, no code fences
+7. Keep journey_title SHORT: 3–6 words
+${typeFieldRule}
+${onlyTypesRule}
+
+Response format (exact field names):
+{
+  "journey_title": "Short, warm title (3-6 words)",
+  "description": "2-4 sentences telling the ${audience} what emotional experience awaits${options.inputItemCount > maxItems ? "; include honest rationale for which items were left out" : ""}",
+  "total_runtime_minutes": 0,
+  "difficulty_progression": "e.g. light & inviting → emotionally rich → deeply moving",
+  "items": [
+    {
+      "position": 1,
+      "title": "Exact title from input",
+      "creator": "Director/Showrunner/Author",
+      "year": 2020,
+      "type": "${exampleType}",
+      "description": "1-2 sentences: why a friend would love this right now, at this point in the journey",
+      "genres": ["Genre1", "Genre2"],
+      "whyThisPosition": "The emotional logic: what mood are they in, and why does this meet them there?",
+      "whatYoullLearn": "A personal, relatable insight — what this will make them feel or realize",
+      "keyThemes": ["theme1", "theme2"],
+      "difficultyLevel": "beginner",
+      "ratingScore": 8.0,
+      "popularityScore": 80,
+      "transitionToNext": "How they likely feel now + why the next piece is what they need — or null if last"
+    }
+  ]
+}
+
+Use "difficultyLevel" as emotional weight: "beginner" = lighter and accessible, "intermediate" = emotionally engaging, "advanced" = intense or heavy.
+Audience framing: ${audience}`;
 }

--- a/src/lib/ai-openai.ts
+++ b/src/lib/ai-openai.ts
@@ -3,11 +3,16 @@ import {
   AIResponse,
   ContentType,
   JourneyAIResponse,
+  PromoteItem,
   RefineAnswer,
   RefineResponse,
 } from "./types";
 import { getSystemPrompt } from "./ai-prompts";
-import { getJourneySystemPrompt } from "./ai-journey-prompts";
+import {
+  buildJourneyFromListUserMessage,
+  getJourneyFromListPrompt,
+  getJourneySystemPrompt,
+} from "./ai-journey-prompts";
 import { getRefineSystemPrompt } from "./ai-refine-prompts";
 import { cleanAndParseJSON } from "./ai-utils";
 
@@ -103,6 +108,59 @@ export async function generateJourneyWithOpenAI(
   return cleanAndParseJSON<JourneyAIResponse>(content);
 }
 
+export async function generateJourneyFromListWithOpenAI(
+  items: PromoteItem[],
+  type: ContentType | ContentType[],
+  options: {
+    collectionName: string;
+    collectionDescription?: string | null;
+    maxItems?: number;
+    userContext?: import("./types").UserRecommendContext;
+    maxOutputTokens?: number;
+    temperature?: number;
+    responseMimeType?: string;
+  },
+): Promise<JourneyAIResponse> {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    throw new Error("OPENAI_API_KEY is required for OpenAI provider");
+  }
+
+  const client = new OpenAI({ apiKey });
+  const model = process.env.OPENAI_MODEL || "gpt-4o-mini";
+
+  const userMessage = buildJourneyFromListUserMessage(
+    items,
+    options.collectionName,
+    options.collectionDescription,
+  );
+
+  const completion = await client.chat.completions.create({
+    model,
+    max_tokens: options.maxOutputTokens || 6000,
+    temperature: options.temperature ?? 0.7,
+    messages: [
+      {
+        role: "system",
+        content: getJourneyFromListPrompt(type, {
+          maxItems: options.maxItems,
+          userContext: options.userContext,
+          inputItemCount: items.length,
+        }),
+      },
+      { role: "user", content: userMessage },
+    ],
+    response_format: { type: "json_object" },
+  });
+
+  const content = completion.choices[0]?.message?.content;
+  if (!content) {
+    throw new Error("No content in OpenAI response");
+  }
+
+  return cleanAndParseJSON<JourneyAIResponse>(content);
+}
+
 export async function generateRefineWithOpenAI(
   query: string,
   type: ContentType | ContentType[],
@@ -134,7 +192,36 @@ export async function generateRefineWithOpenAI(
       },
       { role: "user", content: query },
     ],
-    response_format: { type: "json_object" },
+    response_format: {
+      type: "json_schema",
+      json_schema: {
+        name: "refine_response",
+        strict: true,
+        schema: {
+          type: "object",
+          properties: {
+            questions: {
+              type: "array",
+              items: {
+                type: "object",
+                properties: {
+                  id: { type: "string" },
+                  text: { type: "string" },
+                  options: { type: "array", items: { type: "string" } },
+                  multiSelect: { type: "boolean" },
+                },
+                required: ["id", "text", "options", "multiSelect"],
+                additionalProperties: false,
+              },
+            },
+            isComplete: { type: "boolean" },
+            refinedQuery: { type: ["string", "null"] },
+          },
+          required: ["questions", "isComplete", "refinedQuery"],
+          additionalProperties: false,
+        },
+      },
+    },
   });
 
   const content = completion.choices[0]?.message?.content;

--- a/src/lib/ai-prompts.ts
+++ b/src/lib/ai-prompts.ts
@@ -100,32 +100,46 @@ export function getSystemPrompt(
     ? formatUserContextBlock(options.userContext)
     : "";
 
-  return `${userContextBlock}You are an expert media curator with encyclopedic knowledge of ${typeLabel}. 
-Given a user's natural language query describing themes, moods, styles, or preferences, 
-generate a curated collection of ${itemCount}.
+  return `${userContextBlock}You're putting together a list of ${typeLabel} for a friend who just told you what they're in the mood for. You know their taste, you care about getting it right, and you'd only recommend something you'd genuinely stake your reputation on. Think like a thoughtful friend, not a critic or algorithm.
 
-IMPORTANT RULES:
+Given a user's query describing themes, moods, styles, or preferences, generate a curated list of ${itemCount}.
+
+QUALITY & FIT (read the room):
+- Match the list to the user's intent. If they say "best of 2024", "top rated", "must-watch", or "greatest" — they mean it. Lean heavily on critically acclaimed, widely loved titles. This is not the time for hidden gems or personal picks — give them the consensus greats.
+- If the query is more exploratory or mood-based ("cozy rainy day vibes", "movies that make you think"), then you have more freedom. Mix well-known titles with lesser-known ones that genuinely fit — but only if they truly belong, not for variety's sake.
+- When in doubt, ask yourself: "Would a friend actually recommend this for what they asked?" If the answer is "only because it's technically good" — leave it out.
+
+HOW TO PICK EACH TITLE:
+- Every pick should make the user think "yes, this is exactly what I was looking for." If it doesn't clearly fit the mood or theme they described, leave it out.
+- The list should feel cohesive. Every item should feel like it belongs alongside the others — like they share a sensibility, a mood, or an energy that ties them together.
+- "description": Tell them why they'll love this one. Speak to how it'll make them feel, what makes it special, or what moment will stick with them — not to film theory, technique, or critical acclaim. Write like you're texting a friend, not writing a review.
+- NO GIMMICKS: Don't include something just because it's a classic, award-winner, or "important." Every title earns its spot by genuinely fitting what the user asked for.
+
+ITEM COUNT: You MUST return at least ${itemCount}. The user wants a full pool to choose from. Never return fewer unless the query is so specific that fewer titles genuinely exist (e.g. "single-season sci-fi from 2024 on Apple TV+"). If in doubt, include more rather than fewer.
+
+COLLECTION IDENTITY:
+- "collectionTitle": Short (3-6 words), warm and evocative. It should feel like a playlist name a friend would text you, not a Wikipedia category. e.g. "For When You Need a Good Cry", "Stories That Stay With You", "Quiet Films, Loud Feelings."${titleHint}
+- "collectionDescription": Write it like you're handing this list to a friend: "You said you wanted X — so here, these are the ones I'd actually vouch for." Be specific about the mood or feeling they'll get, not a dry summary of the theme.
+
+STRICT RULES:
 - Return ONLY valid JSON, no markdown, no code fences, no explanation
-- Include roughly 60% recognizable titles and 40% hidden gems. Avoid listing only obvious blockbusters.
-- Each recommendation must have a specific 1-2 sentence description tying concrete aspects (a scene, a theme, a technique) to the query — avoid generic praise.
-- STRICT CONSTRAINT ENFORCEMENT: If the user specifies a year or date range (e.g. "2015+", "after 2020", "from the 90s", "pre-2000"), you MUST ONLY include items that satisfy that constraint. Every "year" field in your response must fall within the specified range. Do not include older titles when they ask for recent/modern only.
+- CONSTRAINT ENFORCEMENT: If the user specifies a year or date range (e.g. "2015+", "after 2020", "from the 90s", "pre-2000"), you MUST ONLY include items that satisfy that constraint. Every "year" field must fall within the specified range. Do not include older titles when they ask for recent/modern only.
 - SINGLE-SEASON TV: If the user asks for "single-season", "one-season", "one season", "miniseries", "limited series", or similar, you MUST ONLY recommend TV shows with exactly ONE season. Do not include multi-season series (e.g. Stranger Things, Breaking Bad). Prefer limited series, miniseries, and one-and-done shows.
-- BE CREATIVE: Make the collection title evocative and fitting. Keep it SHORT: 3-6 words max (e.g. "Cozy Rainy Day Picks", "Mind-Bending Sci-Fi").${titleHint}
 - QUALITY CONTROL: If the user query specifies "popular", "highly rated", or "high ratings", YOU MUST ONLY INCLUDE ITEMS WITH A MATURE CRITICAL CONSENSUS (e.g., IMDB > 7.5 or Rotten Tomatoes > 80%). Do not take risks on obscure or poorly rated titles for these requests.${typeMixHint}${excludeRule}${streamingRule}
 ${typeFieldRule}
 ${onlyRecommendRule}
 
 Response format:
 {
-  "collectionTitle": "Short, punchy title (3-6 words)",
-  "collectionDescription": "A brief 1-2 sentence description of the collection theme",
+  "collectionTitle": "Short, warm title (3-6 words)",
+  "collectionDescription": "1-2 sentences: what mood/feeling this list delivers, written like you're handing it to a friend",
   "items": [
     {
       "title": "Title of the work",
       "creator": "Director/Showrunner/Author name",
       "year": 2020,
       "type": "${exampleType}",
-      "description": "Why this fits the query - contextual explanation",
+      "description": "Why they'll love this — speak to feeling and experience, not technique or critical praise",
       "genres": ["Genre1", "Genre2"],
       "ratingScore": 8.5,
       "popularityScore": 90

--- a/src/lib/ai-refine-prompts.ts
+++ b/src/lib/ai-refine-prompts.ts
@@ -56,26 +56,29 @@ export function getRefineSystemPrompt(
       return "";
     })();
 
-    return `You are an expert media curator specializing in ${typeLabel}.
+    return `You're a friend who's been listening carefully to what someone wants to watch or read. They told you what they're in the mood for, and you asked a couple of follow-up questions to really nail it down. Now you need to summarize exactly what they're after — specific enough that anyone reading it could pick the perfect ${typeLabel} for them.
 
-The user made an initial query and answered follow-up questions to refine their preferences.
+The user made an initial query and answered follow-up questions:
 ${answersContext}
 
-Based on ALL the information above, create a single, detailed, natural-language query that captures their full intent. This refined query will be fed into a recommendation engine.
+Based on everything above, write a single, detailed query that captures what they actually want — the mood, the feeling, the vibe, the specifics. This will be used to generate their recommendations.
 
 IMPORTANT RULES:
 - Return ONLY valid JSON, no markdown, no code fences
-- The refined query should be 1-3 sentences, rich with specific preferences
-- The refined query must be CONCRETE and ACTIONABLE: include specific adjectives, eras, tones, and subgenres the user chose — no vague phrases like "something good"
-- Always state an explicit release timeframe or era for recommendations when the user gave any timing preference (e.g. "released in the last 5 years", "1990s–2000s", "classic pre-1970") — infer reasonably from their query and answers if they implied timing without naming years
+- The refined query should be 1-3 sentences that feel natural and specific — like describing to a friend exactly what you're craving
+- Be CONCRETE: include the mood, tone, era, and specifics they chose. "Dark, slow-burn thrillers from the last 5 years that keep you guessing" is good. "Something good and thrilling" is not.
+- Always state an explicit release timeframe or era when the user gave any timing preference (e.g. "released in the last 5 years", "1990s–2000s", "classic pre-1970") — infer reasonably from their query and answers if they implied timing without naming years
+- Capture what they want to FEEL, not just the genre. If they chose "cozy" and "heartwarming," the query should convey that warmth, not just list it as a filter.
 - Incorporate all their answers naturally${typeInstruction}${streamingInstruction}
 
-Response format:
+STRICT JSON SCHEMA — your response MUST match this exactly:
 {
   "questions": [],
   "isComplete": true,
-  "refinedQuery": "A detailed natural-language query incorporating all user preferences"
-}`;
+  "refinedQuery": "string (REQUIRED when isComplete is true)"
+}
+
+Every field is mandatory. "questions" must be an empty array. "isComplete" must be true. "refinedQuery" must be a non-empty string.`;
   }
 
   const round = previousAnswers.length + 1;
@@ -108,39 +111,44 @@ Response format:
     dateRangeHint = `\n\nRELEASE DATE RANGE (REQUIRED): They have not yet locked in a release timeframe. Include exactly ONE question about release date range or era tailored to their query. Use id "release_window".`;
   }
 
-  return `You are an expert media curator specializing in ${typeLabel}.
+  const mediaTypeRule = `\nMEDIA TYPE ALREADY CHOSEN: The user already selected ${typeLabel} as their media type(s) before reaching you. Do NOT ask what type of media they want (movies vs shows vs books etc.) — that's already decided. Focus your questions on mood, tone, pacing, era, and other dimensions of their query.`;
 
-Analyze the user's query to understand their intent and generate follow-up questions that will help create better, more personalized recommendations.
+  return `You're a friend helping someone figure out exactly what they're in the mood for. They told you "${typeLabel}" and gave you a starting point, and now you're having a quick back-and-forth to really nail it — the way you'd naturally ask "wait, do you want something heavy or light?" before picking a movie together.
+
+Your job: ask ${round === 1 ? "the first round of" : "a second round of"} follow-up questions based on what they've told you so far.
 ${answersContext}
-
-This is round ${round} of follow-up questions.${
+${
     round === 1
-      ? " Ask questions directly relevant to their query. If they mentioned a genre or theme, ask about sub-preferences within that (tone, length, etc.). The release-window question (see below) covers timing; keep the other two questions on mood, pacing, format, or subgenre."
-      : " Build on their previous answers to drill deeper into their taste. NEVER ask about something they already answered. Each round must explore a DIFFERENT dimension (e.g., if round 1 covered mood, round 2 should cover era, length, or style — not the same axis)."
-  }${userContextHint}${streamingHint}${dateRangeHint}
+      ? `React to their specific query — your questions should feel like a direct response to what they just said. If they said "best of 2024", ask about genres or moods within that, not generic preference questions. If they mentioned a genre or vibe, dig into what kind. The release-window question (see below) covers timing; keep the other two questions on aspects that are genuinely relevant to THEIR query.`
+      : "Build on what they've already shared — your questions should feel like the next natural thing to ask in the conversation. NEVER re-ask something they already answered. Each question should explore a NEW dimension that would genuinely help narrow down what they want."
+  }${userContextHint}${streamingHint}${dateRangeHint}${mediaTypeRule}
 
 IMPORTANT RULES:
 - Return ONLY valid JSON, no markdown, no code fences
 - Generate exactly 3 questions
 - Each question must cover a DIFFERENT aspect — not 3 variations of the same question (e.g., one about release window, one about tone, one about length/format)
 - NEVER repeat themes from previous questions. Do not ask about something the user already answered
+- NEVER ask about media type (movies/shows/books/anime) — the user already chose ${typeLabel}
 - Each question should have 3-5 concise options (1-4 words each)
-- Questions should feel conversational and fun, not clinical
-- Options should be diverse and cover different angles
+- Questions must feel like a natural response to THEIR specific query. If they said "best thrillers", ask about what kind of thrillers. If they said "feel-good comedies", ask about the mood within that. Generic questions like "What genre interests you?" are lazy — dig into what they actually asked for.
+- Options should be distinct and cover genuinely different angles — not synonyms
 - Set multiSelect to true when multiple options can apply (e.g., moods, themes)
 - Set multiSelect to false for either/or choices (e.g., era preference)
 - Each question needs a unique id (e.g., "q1", "q2", "q3")
 
-Response format:
+STRICT JSON SCHEMA — your response MUST match this exactly:
 {
   "questions": [
     {
-      "id": "q${round}_1",
-      "text": "A conversational question about their preferences?",
-      "options": ["Option A", "Option B", "Option C", "Option D"],
-      "multiSelect": true
+      "id": "string (REQUIRED — unique per question, e.g. q${round}_1)",
+      "text": "string (REQUIRED — the question text)",
+      "options": ["string", "string", "string"] (REQUIRED — array of 3-5 option strings, NEVER empty, NEVER omit this field),
+      "multiSelect": boolean (REQUIRED — true or false)
     }
   ],
-  "isComplete": false
-}`;
+  "isComplete": false,
+  "refinedQuery": null
+}
+
+CRITICAL: Every question object MUST have all 4 fields: "id", "text", "options", "multiSelect". The "options" field MUST be a non-empty array of strings. Do NOT use any other field names (not "choices", not "answers", not "values" — only "options"). Omitting any field will break the application.`;
 }

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -2,22 +2,26 @@ import {
   AIResponse,
   ContentType,
   JourneyAIResponse,
+  PromoteItem,
   RefineAnswer,
   RefineResponse,
 } from "./types";
 import {
   generateWithGemini,
   generateJourneyWithGemini,
+  generateJourneyFromListWithGemini,
   generateRefineWithGemini,
 } from "./ai-gemini";
 import {
   generateWithOpenAI,
   generateJourneyWithOpenAI,
+  generateJourneyFromListWithOpenAI,
   generateRefineWithOpenAI,
 } from "./ai-openai";
 import {
   generateWithAnthropic,
   generateJourneyWithAnthropic,
+  generateJourneyFromListWithAnthropic,
   generateRefineWithAnthropic,
 } from "./ai-anthropic";
 import { withRetry } from "./ai-retry";
@@ -99,6 +103,43 @@ export async function generateJourney(
     default:
       raw = await withRetry(() =>
         generateJourneyWithGemini(query, type, options),
+      );
+  }
+
+  return normalizeJourneyResponse(raw);
+}
+
+export async function generateJourneyFromList(
+  items: PromoteItem[],
+  type: ContentType | ContentType[],
+  options: {
+    collectionName: string;
+    collectionDescription?: string | null;
+    maxItems?: number;
+    userContext?: import("./types").UserRecommendContext;
+    maxOutputTokens?: number;
+    temperature?: number;
+    responseMimeType?: string;
+  },
+): Promise<JourneyAIResponse> {
+  const provider = process.env.AI_PROVIDER || "gemini";
+  let raw: JourneyAIResponse;
+
+  switch (provider) {
+    case "openai":
+      raw = await withRetry(() =>
+        generateJourneyFromListWithOpenAI(items, type, options),
+      );
+      break;
+    case "anthropic":
+      raw = await withRetry(() =>
+        generateJourneyFromListWithAnthropic(items, type, options),
+      );
+      break;
+    case "gemini":
+    default:
+      raw = await withRetry(() =>
+        generateJourneyFromListWithGemini(items, type, options),
       );
   }
 

--- a/src/lib/promote-journey.ts
+++ b/src/lib/promote-journey.ts
@@ -1,0 +1,69 @@
+import type { JourneyItem, JourneyItemRaw, PromoteItem } from "./types";
+
+function normalizeTitle(t: string): string {
+  return t.trim().toLowerCase().replace(/\s+/g, " ");
+}
+
+/**
+ * Merge AI journey output with original list items (posters, ids, runtime, ratings).
+ */
+export function mergePromotedJourneyItems(
+  rawItems: JourneyItemRaw[],
+  promoteItems: PromoteItem[],
+): JourneyItem[] {
+  const pool = promoteItems.map((p, i) => ({ p, i }));
+  const used = new Set<number>();
+
+  return rawItems.map((raw, idx) => {
+    const nt = normalizeTitle(raw.title);
+    let matchIdx = pool.findIndex(
+      ({ p, i }) =>
+        !used.has(i) &&
+        normalizeTitle(p.title) === nt &&
+        p.year === raw.year,
+    );
+    if (matchIdx === -1) {
+      matchIdx = pool.findIndex(
+        ({ p, i }) => !used.has(i) && normalizeTitle(p.title) === nt,
+      );
+    }
+
+    let base: PromoteItem | undefined;
+    if (matchIdx !== -1) {
+      const { p, i } = pool[matchIdx]!;
+      used.add(i);
+      base = p;
+    }
+
+    const position = raw.position ?? idx + 1;
+    return {
+      title: raw.title,
+      creator: raw.creator,
+      year: raw.year,
+      type: raw.type,
+      description: raw.description ?? base?.description ?? "",
+      genres: raw.genres?.length ? raw.genres : base?.genres ?? [],
+      whyThisPosition: raw.whyThisPosition,
+      whatYoullLearn: raw.whatYoullLearn,
+      keyThemes: raw.keyThemes ?? [],
+      difficultyLevel: raw.difficultyLevel,
+      transitionToNext: raw.transitionToNext,
+      position,
+      posterUrl: base?.posterUrl ?? null,
+      rating: base?.rating ?? null,
+      ratingSource: base?.ratingSource ?? null,
+      runtime: base?.runtime ?? null,
+      externalId: base?.externalId ?? null,
+    };
+  });
+}
+
+export function inferContentTypeFromPromoteItems(
+  items: PromoteItem[],
+): import("./types").ContentType | import("./types").ContentType[] {
+  const types = new Set(items.map((i) => i.type));
+  if (types.size === 1) {
+    return items[0]!.type;
+  }
+  return "all";
+}

--- a/src/lib/supabase/database.types.ts
+++ b/src/lib/supabase/database.types.ts
@@ -455,6 +455,7 @@ export type Database = {
           query: string;
           review_text: string | null;
           sequence_rating: number | null;
+          source_collection_id: string | null;
           started_at: string | null;
           status: string | null;
           title: string;
@@ -484,6 +485,7 @@ export type Database = {
           query: string;
           review_text?: string | null;
           sequence_rating?: number | null;
+          source_collection_id?: string | null;
           started_at?: string | null;
           status?: string | null;
           title: string;
@@ -513,6 +515,7 @@ export type Database = {
           query?: string;
           review_text?: string | null;
           sequence_rating?: number | null;
+          source_collection_id?: string | null;
           started_at?: string | null;
           status?: string | null;
           title?: string;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -17,6 +17,21 @@ export interface AIResponse {
   items: AIRecommendation[];
 }
 
+/** Items passed to AI when promoting a collection to a journey */
+export interface PromoteItem {
+  title: string;
+  year: number;
+  type: "movie" | "tv" | "book" | "anime";
+  genres: string[];
+  description?: string;
+  creator?: string;
+  posterUrl?: string | null;
+  externalId?: string | null;
+  runtime?: string | null;
+  rating?: number | null;
+  ratingSource?: string | null;
+}
+
 export interface EnrichedRecommendation extends AIRecommendation {
   posterUrl: string | null;
   rating: number | null;

--- a/supabase/migrations/20260404120000_journeys_source_collection.sql
+++ b/supabase/migrations/20260404120000_journeys_source_collection.sql
@@ -1,0 +1,7 @@
+-- Link journeys created by promoting a collection (one promotion per collection)
+ALTER TABLE journeys
+  ADD COLUMN IF NOT EXISTS source_collection_id UUID REFERENCES collections(id) ON DELETE SET NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_journeys_source_collection
+  ON journeys(source_collection_id)
+  WHERE source_collection_id IS NOT NULL;


### PR DESCRIPTION
- Add functionality to promote collections to journeys, allowing users to create a journey from their curated lists.
- Introduce a modal for confirming the promotion action with user feedback on item selection.
- Enhance journey creation with AI-generated recommendations based on collection items.
- Update relevant components to handle the new journey promotion logic and state management.
- Include new constants for maximum items in a journey and curating messages for improved user experience.